### PR TITLE
fix deprecated usage of np.float and np.complex

### DIFF
--- a/vampyre/estim/gaussian.py
+++ b/vampyre/estim/gaussian.py
@@ -44,7 +44,7 @@ class GaussEst(BaseEst):
         if is_complex:
             dtype = np.double
         else:
-            dtype = np.complex
+            dtype = np.complex128
              
         BaseEst.__init__(self,shape=shape,dtype=dtype,name=name,
                          var_axes=var_axes,type_name='GaussEst', cost_avail=True)

--- a/vampyre/estim/gaussian.py
+++ b/vampyre/estim/gaussian.py
@@ -42,9 +42,9 @@ class GaussEst(BaseEst):
         if np.isscalar(shape):
             shape = (shape,)
         if is_complex:
-            dtype = np.double
-        else:
             dtype = np.complex128
+        else:
+            dtype = np.double
              
         BaseEst.__init__(self,shape=shape,dtype=dtype,name=name,
                          var_axes=var_axes,type_name='GaussEst', cost_avail=True)

--- a/vampyre/trans/convolve2d.py
+++ b/vampyre/trans/convolve2d.py
@@ -67,7 +67,7 @@ class Convolve2DLT(BaseLinTrans):
         self.srep_axes = self.chan_axes
         
         # Superclass constructor
-        dtype = np.float
+        dtype = np.float64
         BaseLinTrans.__init__(self, shape, shape, dtype, dtype,\
                               svd_avail=True,name='Convolve2D')
 


### PR DESCRIPTION
np.float and np.complex data types have been removed in latest numpy release and should be replaced with np.float64 and np.complex128. While at it also fix swapped dtypes in gaussian.py